### PR TITLE
年度ごとのGPAと、合計のGPAを算出する（修正）

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,8 +4,17 @@ import read_csv, calc
 # mainの定義
 def main():
   df = read_csv.load_csv('row_score.csv')
-  gpa = calc.get_gpa(list(df['評価']), list(df['単位']))
-  print("あなたのGPAは，" + str(gpa) + "です．")
+  df_2020 = df[df['年度'] == '2020']
+  gpa_2020 = calc.get_gpa(list(df_2020['評価']), list(df_2020['単位']))
+  df_2021 = df[df['年度'] == '2021']
+  gpa_2021 = calc.get_gpa(list(df_2021['評価']), list(df_2021['単位']))
+  df_2022 = df[df['年度'] == '2022']
+  gpa_2022 = calc.get_gpa(list(df_2022['評価']), list(df_2022['単位']))
+  gpa_all = calc.get_gpa(list(df['評価']), list(df['単位']))
+  print("あなたの2020年度のGPAは，" + str(format(gpa_2020,".2f")) + "です．")
+  print("あなたの2021年度のGPAは，" + str(format(gpa_2021,".2f")) + "です．")
+  print("あなたの2022年度のGPAは，" + str(format(gpa_2022,".2f")) + "です．")
+  print("あなたの現在のGPAは，    " + str(format(gpa_all,".2f")) + "です．")
 
 # main関数の実行
 if __name__ == '__main__':


### PR DESCRIPTION
現状では、3年間合計のGPAのみ出力されているため、2020、2021、2022年の年度ごとのGPAも出力するようにする。 また、有効数字は2桁に設定する。

修正後は、

あなたの2020年度のGPAは，2.66です．
あなたの2021年度のGPAは，2.34です．
あなたの2022年度のGPAは，2.65です．
あなたの現在のGPAは，    2.54です．

というように出力される。

再現手順は現状と同じである。